### PR TITLE
Fix resources test error

### DIFF
--- a/selenium_tests/resources/party_resources.py
+++ b/selenium_tests/resources/party_resources.py
@@ -16,6 +16,8 @@ class PartyResource(SeleniumTestCase):
 
         self.wd.find_element_by_link_text("party-1").click()
         self.wd.wait_for_xpath("//h2[contains(text(), 'Party detail')]")
+        self.wd.find_element_by_link_text("Resources").click()
+        self.wd.wait_for_xpath("//*[@id=\"resources\"][contains(@class, 'active')]")
         self.wd.find_element_by_link_text("Attach").click()
         self.wd.switch_to_window(self.wd.window_handles[-1])
         try :
@@ -42,6 +44,8 @@ class PartyResource(SeleniumTestCase):
 
         self.wd.find_element_by_link_text("party-1").click()
         self.wd.wait_for_xpath("//h2[contains(text(), 'Party detail')]")
+        self.wd.find_element_by_link_text("Resources").click()
+        self.wd.wait_for_xpath("//*[@id=\"resources\"][contains(@class, 'active')]")
         self.wd.find_element_by_link_text("Attach").click()
         self.wd.switch_to_window(self.wd.window_handles[-1])
         self.wd.find_element_by_xpath('//tr/td/label/strong[contains(text(), "resource-1")]').click()
@@ -56,6 +60,8 @@ class PartyResource(SeleniumTestCase):
 
         self.wd.find_element_by_link_text("party-1").click()
         self.wd.wait_for_xpath("//h2[contains(text(), 'Party detail')]")
+        self.wd.find_element_by_link_text("Resources").click()
+        self.wd.wait_for_xpath("//*[@id=\"resources\"][contains(@class, 'active')]")
         self.wd.find_element_by_xpath("//button[@role='button']").click()
         assert self.wd.wait_for_xpath("//h2[contains(text(), 'Party detail')]")
 


### PR DESCRIPTION
The following tests

- test_add_new_resource_to_party
- test_attach_existing_resource_to_party
- test_detach_resource_from_party

were producing an  `Unable to locate element` error because of the tab not being switched to Resources.

This PR adds a click to switch the tab and a wait until it loads before progressing with the test.


Here's the full error log prior to the fix:

```
======================================================================
ERROR: test_add_new_resource_to_party (selenium_tests.resources.party_resources.PartyResource)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/shaily/docs/oss/cadasta/cadasta-test/selenium_tests/resources/party_resources.py", line 19, in test_add_new_resource_to_party
    self.wd.find_element_by_link_text("Attach").click()
  File "/usr/lib/python2.7/site-packages/selenium/webdriver/remote/webdriver.py", line 317, in find_element_by_link_text
    return self.find_element(by=By.LINK_TEXT, value=link_text)
  File "/usr/lib/python2.7/site-packages/selenium/webdriver/remote/webdriver.py", line 752, in find_element
    'value': value})['value']
  File "/usr/lib/python2.7/site-packages/selenium/webdriver/remote/webdriver.py", line 236, in execute
    self.error_handler.check_response(response)
  File "/usr/lib/python2.7/site-packages/selenium/webdriver/remote/errorhandler.py", line 192, in check_response
    raise exception_class(message, screen, stacktrace)
NoSuchElementException: Message: no such element: Unable to locate element: {"method":"link text","selector":"Attach"}
  (Session info: chrome=56.0.2924.87)
  (Driver info: chromedriver=2.27.440175 (9bc1d90b8bfa4dd181fbbf769a5eb5e575574320),platform=Linux 4.9.13-200.fc25.x86_64 x86_64)


======================================================================
ERROR: test_attach_existing_resource_to_party (selenium_tests.resources.party_resources.PartyResource)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/shaily/docs/oss/cadasta/cadasta-test/selenium_tests/resources/party_resources.py", line 45, in test_attach_existing_resource_to_party
    self.wd.find_element_by_link_text("Attach").click()
  File "/usr/lib/python2.7/site-packages/selenium/webdriver/remote/webdriver.py", line 317, in find_element_by_link_text
    return self.find_element(by=By.LINK_TEXT, value=link_text)
  File "/usr/lib/python2.7/site-packages/selenium/webdriver/remote/webdriver.py", line 752, in find_element
    'value': value})['value']
  File "/usr/lib/python2.7/site-packages/selenium/webdriver/remote/webdriver.py", line 236, in execute
    self.error_handler.check_response(response)
  File "/usr/lib/python2.7/site-packages/selenium/webdriver/remote/errorhandler.py", line 192, in check_response
    raise exception_class(message, screen, stacktrace)
NoSuchElementException: Message: no such element: Unable to locate element: {"method":"link text","selector":"Attach"}
  (Session info: chrome=56.0.2924.87)
  (Driver info: chromedriver=2.27.440175 (9bc1d90b8bfa4dd181fbbf769a5eb5e575574320),platform=Linux 4.9.13-200.fc25.x86_64 x86_64)


======================================================================
ERROR: test_detach_resource_from_party (selenium_tests.resources.party_resources.PartyResource)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/shaily/docs/oss/cadasta/cadasta-test/selenium_tests/resources/party_resources.py", line 59, in test_detach_resource_from_party
    self.wd.find_element_by_xpath("//button[@role='button']").click()
  File "/usr/lib/python2.7/site-packages/selenium/webdriver/remote/webdriver.py", line 293, in find_element_by_xpath
    return self.find_element(by=By.XPATH, value=xpath)
  File "/usr/lib/python2.7/site-packages/selenium/webdriver/remote/webdriver.py", line 752, in find_element
    'value': value})['value']
  File "/usr/lib/python2.7/site-packages/selenium/webdriver/remote/webdriver.py", line 236, in execute
    self.error_handler.check_response(response)
  File "/usr/lib/python2.7/site-packages/selenium/webdriver/remote/errorhandler.py", line 192, in check_response
    raise exception_class(message, screen, stacktrace)
NoSuchElementException: Message: no such element: Unable to locate element: {"method":"xpath","selector":"//button[@role='button']"}
  (Session info: chrome=56.0.2924.87)
  (Driver info: chromedriver=2.27.440175 (9bc1d90b8bfa4dd181fbbf769a5eb5e575574320),platform=Linux 4.9.13-200.fc25.x86_64 x86_64)

```