### PR TITLE
Fix test_password_change_success

### DIFF
--- a/cadasta_test_suites.py
+++ b/cadasta_test_suites.py
@@ -196,7 +196,7 @@ cadasta_accounts_test_suite = unittest.TestSuite([
     empty_username_in_password_validation,
     empty_email_in_password_validation,
     password_reset,
-    # password_change,
+    password_change,
     username_change,
     fullname_change,
     # email_change

--- a/selenium_tests/accounts/user_profile.py
+++ b/selenium_tests/accounts/user_profile.py
@@ -36,8 +36,9 @@ class PasswordChange(SeleniumTestCase):
         self.wd.find_css('#id_password2').send_keys("XYZ#qwertyA")
         self.wd.find_elements_by_xpath("//button[contains(text(), 'Change password')]")[0].click()
         text = self.wd.find_element_by_xpath("//h1").text
+        assert text == "Update your profile"
+        self.open("/account/logout/")
         self.restore_password("XYZ#qwerty", "XYZ#qwertyA")
-        assert text == "Change your password"
 
     def test_password_change_failure(self):
         self.user_login()


### PR DESCRIPTION
This test is currently commented out of `cadasta_test_suites.py`, probably because it doesn't work.

The fix involves changing the text to "Update your profile" since that's what appears on the page after a successful password change.
Also, `self.restore_password` involves logging in again, so we logout before calling it.

I'm not sure why it was left out in the beginning, but I ran the tests after this fix, and they ran fine.