### PR TITLE
Repo updates

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,12 @@
+root = true
+
+[*]
+indent_style = space
+indent_size = 4
+end_of_line = lf
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+
+[*.md]
+trim_trailing_whitespace = false

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -14,8 +14,8 @@
 
 ## Submitting your Pull Request
 
-- Make sure all tests pass. You can run the tests locally using `./runtests.py` in the `/vagrant/` directory. 
-- Make sure your changes pass checks for coding style. You run the checks locally using `./runtests.py --lint` in the `/vagrant/` directory.
+- Make sure all tests pass. You can run the tests locally using `./runtests.py` in the `cadasta-test/` directory. 
+- Make sure your changes pass checks for coding style. You run the checks locally using `./runtests.py --lint` in the `cadasta-test/` directory.
 - Give your pull request a meaningful title. The pull request title will end up as the commit message in the commit history. For a bug fix a pull request title could read "Fixes #123 -- Make sure usernames are not case-sensitive". 
 - If this is a bug fix, link the issue you are addressing in the PR description. Github makes this easy when you type `#123` (123 is the number of the issue) the text is automatically linked. 
 - When you open a new pull request, you will find four questions that help you to provide us the information we need to review your PR. You should respond to the first question (_Proposed changes in this pull request_) sufficiently. Please describe the changes you have made and why you had to make those changes. If your PR fixes a bug, please include a description of the cause of the bug as well. 

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -1,0 +1,25 @@
+# Contributing
+
+## Getting started
+
+- Fork the repository on Github
+- Install the Cadasta Platform development environment. Follow the instructions in the [cadasta-platform README](https://github.com/Cadasta/cadasta-platform/blob/master/README.rst#install-for-development).
+- Configure the development environment for running Cadasta Test Suite. Follow the instructions in the [cadasta-test README](https://github.com/Cadasta/cadasta-test/blob/master/README.md).
+
+## Making Changes
+
+- From the `master` branch in the `cadasta-test` repo, create a new branch that will contain all of your work. 
+- Give your topic branch a meaningful name. For example, if you're working on a bug fix for issue #123, you could call your branch `bugfix/#123`.
+- Add tests. Whether you fix a bug or add a new feature, you must add tests to verify your code is working as expected. 
+
+## Submitting your Pull Request
+
+- Make sure all tests pass. You can run the tests locally using `./runtests.py` in the `/vagrant/` directory. 
+- Make sure your changes pass checks for coding style. You run the checks locally using `./runtests.py --lint` in the `/vagrant/` directory.
+- Give your pull request a meaningful title. The pull request title will end up as the commit message in the commit history. For a bug fix a pull request title could read "Fixes #123 -- Make sure usernames are not case-sensitive". 
+- If this is a bug fix, link the issue you are addressing in the PR description. Github makes this easy when you type `#123` (123 is the number of the issue) the text is automatically linked. 
+- When you open a new pull request, you will find four questions that help you to provide us the information we need to review your PR. You should respond to the first question (_Proposed changes in this pull request_) sufficiently. Please describe the changes you have made and why you had to make those changes. If your PR fixes a bug, please include a description of the cause of the bug as well. 
+- You do not need to worry about the checklist in the pull request template. The list helps us to remember important things to look at when reviewing. You can use the list, however, as a guideline to prepare your pull request. 
+
+After you submit your pull request, the Cadasta development team will review your changes. 
+

--- a/.github/ISSUE_TEMPLATE
+++ b/.github/ISSUE_TEMPLATE
@@ -1,0 +1,12 @@
+### Steps to reproduce the error
+
+[Please try to describe the actions that led to the incorrect behavior
+in as much detail as possible.]
+
+### Actual behavior
+
+[Please describe the outcome of your actions.]
+
+### Expected behavior
+
+[Please explain what behavior you would have expected instead.]

--- a/.github/PULL_REQUEST_TEMPLATE
+++ b/.github/PULL_REQUEST_TEMPLATE
@@ -1,0 +1,66 @@
+### Proposed changes in this pull request
+
+[List all changes you want to add here. If you fixed an issue, please
+add a reference to that issue as well.]
+
+-
+
+### When should this PR be merged
+
+[Please describe any preconditions that need to be addressed before we
+can merge this pull request.]
+
+-
+
+### Risks
+
+[List any risks that could arise from merging your pull request.]
+
+-
+
+### Follow-up actions
+
+[List any possible follow-up actions here.]
+
+-
+
+
+### Checklist (for reviewing)
+
+#### General
+
+- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
+- [ ] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
+- [ ] **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.
+
+#### Functionality
+
+- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
+- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 
+
+#### Code
+
+- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
+- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
+- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 
+
+#### Tests
+
+- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
+- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
+- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?
+
+#### Security
+
+- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
+- [ ] **Are all UI and API inputs run through forms or serializers?** 
+- [ ] **Are all external inputs validated and sanitized appropriately?**
+- [ ] **Does all branching logic have a default case?**
+- [ ] **Does this solution handle outliers and edge cases gracefully?**
+- [ ] **Are all external communications secured and restricted to SSL?**
+
+#### Documentation
+
+- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
+- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
+- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+.DS_Store
+*.swp
+*.log

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,68 @@
-.DS_Store
-*.swp
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]
+*$py.class
+
+# C extensions
+*.so
+
+# Distribution / packaging
+.Python
+env/
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+*.egg-info/
+.installed.cfg
+*.egg
+
+# PyInstaller
+#  Usually these files are written by a python script from a template
+#  before PyInstaller builds the exe, so as to inject date/other infos into it.
+*.manifest
+*.spec
+
+# Installer logs
+pip-log.txt
+pip-delete-this-directory.txt
+
+# Unit test / coverage reports
+htmlcov/
+.tox/
+.coverage
+.coverage.*
+.cache
+nosetests.xml
+coverage.xml
+*,cover
+.hypothesis/
+
+# Translations
+*.mo
+*.pot
+
+# Basic stuff:
 *.log
+*.swp
+*.DS_Store
+
+# PyBuilder
+target/
+
+# pyenv
+.python-version
+
+# dotenv
+.env
+
+# virtualenv
+venv/
+ENV/


### PR DESCRIPTION
Adds the following repo files:

.gitignore
.editorconfig
PULL_REQUEST_TEMPLATE
ISSUE_TEMPLATE
CONTRIBUTING.md

to bring the cadasta-test repo in line with cadasta-platform. These files are stubs adapted from cadasta-platform, so please update as desired to better reflect cadasta-test needs.

The cadasta-test repo has already been modified to require PR approval and squashed merges for the master branch, as in cadasta-platform.