### PR TITLE
Remove test for password help text

### DIFF
--- a/cadasta/test/account_tests/test_registration.py
+++ b/cadasta/test/account_tests/test_registration.py
@@ -139,13 +139,7 @@ class TestRegistration(SeleniumTestCase):
         self.update_form_field('email', self.email)
         self.update_form_field('full_name', self.full_name)
 
-        password_help = self.wd.BY_XPATH(
-            '(//*[@for="id_password"])[1]/following-sibling::p')
-        assert 'hidden' in password_help.get_attribute('class')
         password_input = self.wd.BY_NAME('password')
-        password_input.click()
-        assert 'hidden' not in password_help.get_attribute('class')
-
         password_input.send_keys('Aa1+')
         self.click_register_button()
         self.assert_form_field_has_error(


### PR DESCRIPTION
### Proposed changes in this pull request

https://github.com/Cadasta/cadasta-platform/pull/1960 removes the `hidden` class from the help text to always show the password help. Thus removing the corresponding test. 

### When should this PR be merged

Before https://github.com/Cadasta/cadasta-platform/pull/1960 is merged.

### Risks

None.

### Follow-up actions

[List any possible follow-up actions here.]

-


### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [ ] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
- [ ] **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?** 
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
