### PR TITLE
Move some tests from batch 1 to batch 2

### DIFF
--- a/cadasta/test/forms_tests/test_xlsform.py
+++ b/cadasta/test/forms_tests/test_xlsform.py
@@ -10,7 +10,7 @@ from ..base_test import SeleniumTestCase
 USER_MENU_XPATH_FORMAT = '//header//*[normalize-space()="{}"]'
 
 
-@pytest.mark.batch1
+@pytest.mark.batch2
 class TestXLSForm(SeleniumTestCase):
 
     @pytest.fixture(autouse=True)

--- a/cadasta/test/organization_tests/test_user_management.py
+++ b/cadasta/test/organization_tests/test_user_management.py
@@ -11,7 +11,7 @@ from ..util import random_string
 USER_MENU_XPATH_FORMAT = '//header//*[normalize-space()="{}"]'
 
 
-@pytest.mark.batch1
+@pytest.mark.batch2
 class TestUserManagement(SeleniumTestCase):
 
     @pytest.fixture(autouse=True)


### PR DESCRIPTION
### Proposed changes in this pull request
**Why:** Batch 1 still takes too long and is hitting the 50-minute timeout of Travis ([see sample log](https://travis-ci.org/Cadasta/cadasta-platform/jobs/339114880)). Also, batch 2 currently does not have any file-uploading tests so this batch will encounter a false negative failure on Travis.

**What:** Move the Organization User Management tests and the XLSForm tests from batch 1 to batch 2. This should reduce the number of tests for batch 1 and also make batch 2 have file-uploading tests.

### When should this PR be merged
Soon.

### Risks
None.

### Follow-up actions
The usual (create a new release then submit a PR for the **cadasta-platform** repo). I would be nice if we can release this together with PR #63.

### Checklist (for reviewing)

#### General

- [ ] **Is this PR explained thoroughly?** All code changes must be accounted for in the PR description. 
- [ ] **Is the PR labeled correctly?** It should have the `migration` label if a new migration is added. 
- [ ] **Is the risk level assessment sufficient?** The risks section should contain all risks that might be introduced with the PR and which actions we need to take to mitigate these risks. Possible risks are database migrations, new libraries that need to be installed or changes to deployment scripts.

#### Functionality

- [ ] **Are all requirements met?** Compare implemented functionality with the requirements specification.
- [ ] **Does the UI work as expected?** There should be no Javascript errors in the console; all resources should load. There should be no unexpected errors. Deliberately try to break the feature to find out if there are corner cases that are not handled. 

#### Code

- [ ] **Do you fully understand the introduced changes to the code?** If not ask for clarification, it might uncover ways to solve a problem in a more elegant and efficient way.
- [ ] **Does the PR introduce any inefficient database requests?** Use the debug server to check for duplicate requests. 
- [ ] **Are all necessary strings marked for translation?** All strings that are exposed to users via the UI must be [marked for translation](https://docs.djangoproject.com/en/1.10/topics/i18n/translation/). 

#### Tests

- [ ] **Are there sufficient test cases?** Ensure that all components are tested individually; models, forms, and serializers should be tested in isolation even if a test for a view covers these components. 
- [ ] **If this is a bug fix, are tests for the issue in place?**  There must be a test case for the bug to ensure the issue won’t regress. Make sure that the tests break without the new code to fix the issue.
- [ ] **If this is a new feature or a significant change to an existing feature?** has the manual testing spreadsheet been updated with instructions for manual testing?

#### Security

- [ ] **Confirm this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets.**
- [ ] **Are all UI and API inputs run through forms or serializers?** 
- [ ] **Are all external inputs validated and sanitized appropriately?**
- [ ] **Does all branching logic have a default case?**
- [ ] **Does this solution handle outliers and edge cases gracefully?**
- [ ] **Are all external communications secured and restricted to SSL?**

#### Documentation

- [ ] **Are changes to the UI documented in the platform docs?** If this PR introduces new platform site functionality or changes existing ones, the changes must be documented in the [Cadasta Platform Documentation](https://github.com/Cadasta/cadasta-docs).
- [ ] **Are changes to the API documented in the API docs?** If this PR introduces new API functionality or changes existing ones, the changes must be documented in the [API docs](https://github.com/Cadasta/api-docs).
- [ ] **Are reusable components documented?** If this PR introduces components that are relevant to other developers (for instance a mixin for a view or a generic form) they should be documented in the Wiki. 
